### PR TITLE
Factor out base prompt and correct prompt language

### DIFF
--- a/code_reviewer.py
+++ b/code_reviewer.py
@@ -14,20 +14,24 @@ CodeDiff = TypedDict(
 )
 
 
+PROMPT_BASE = (
+    "Act as an expert software tech lead during code review.\n"
+    "Take into account that this is only a snippet, it does not contain full code.\n"
+    "Answer in valid json in the following form:\n"
+    '{{"should_comment": bool, "issues": "<possible issues with code with detailed explanation why>", "suggestions": "<suggestions of improvements that can be introduced to code with explanation why"}}\n\n'
+    "Remember to format it readably and include newlines in your answer.\n"
+    "Please work through this in a step by step way to be sure we have the right answer.\n"
+)
+
 class CodeReviewer:
     @staticmethod
     async def review_code_diff(file_name: str, diff: str):
         prompt = (
-            f"Act a expert software tech lead during code review.\n"
-            f"Take into account that this only snippet, it does not contain full code.\n"
-            f"Does this code diffs contain any issues? Can it be improved?\n"
-            f"Answer in valid json format in the following form:\n"
-            f'{{"should_comment": bool, "issues": "<possible issues with code with detailed explanation why>", "suggestions": "<suggestions of improvements that can be introduced to code with explanation why"}}\n\n'
-            f"Let's work this out in a step by step way to be sure we have the right answer.\n"
+            f"{PROMPT_BASE}\n"
             f"```\n"
             f"{diff}\n"
             f"```\n\n"
-            f"Let's work this out in a step by step way to be sure we have the right answer\n"
+            f"Does this diff contain any issues? Can it be improved?\n"
         )
 
         response = openai.ChatCompletion.create(
@@ -47,15 +51,6 @@ class CodeReviewer:
 
     @staticmethod
     async def review_code_diffs(diffs: list[CodeDiff]):
-        initial_prompt = (
-            f"Act a expert software tech lead during code review.\n"
-            f"Take into account that this only snippet, it does not contain full code.\n"
-            f"Does this code diffs contain any issues? Can it be improved?\n"
-            f"Answer in valid json format in the following form:\n"
-            f'{{"should_comment": bool, "issues": "<possible problems with code with detailed explanation why>", "suggestions": "<suggestions of improvements that can be introduced to code with explanation why"}}\n\n'
-            f"Remember to format it readably and add new lines to your answer.\n"
-        )
-
         diff_messages = [
             {
                 "role": "user",
@@ -66,11 +61,11 @@ class CodeReviewer:
         response = openai.ChatCompletion.create(
             model=config.GPT_MODEL,
             messages=[
-                {"role": "system", "content": initial_prompt},
+                {"role": "system", "content": PROMPT_BASE},
                 *diff_messages,
                 {
-                    "role": "user",
-                    "content": "Let's work this out in a step by step way to be sure we have the right answer\n",
+                    "role": "user", 
+                    "content": "Do these diffs contain any issues? Can they be improved?\n"
                 },
             ],
         )

--- a/code_reviewer.py
+++ b/code_reviewer.py
@@ -20,8 +20,11 @@ PROMPT_BASE = (
     "Answer in valid json in the following form:\n"
     '{{"should_comment": bool, "issues": "<possible issues with code with detailed explanation why>", "suggestions": "<suggestions of improvements that can be introduced to code with explanation why"}}\n\n'
     "Remember to format it readably and include newlines in your answer.\n"
-    "Please work through this in a step by step way to be sure we have the right answer.\n"
 )
+
+# Having this exact phrase at the *end* of the prompt improves results
+# https://openreview.net/forum?id=92gvk82DE-
+STEP_BY_STEP = "Let’s work this out in a step by step way to be sure we have the right answer"
 
 class CodeReviewer:
     @staticmethod
@@ -32,6 +35,7 @@ class CodeReviewer:
             f"{diff}\n"
             f"```\n\n"
             f"Does this diff contain any issues? Can it be improved?\n"
+            f"{STEP_BY_STEP}"
         )
 
         response = openai.ChatCompletion.create(
@@ -65,7 +69,10 @@ class CodeReviewer:
                 *diff_messages,
                 {
                     "role": "user", 
-                    "content": "Do these diffs contain any issues? Can they be improved?\n"
+                    "content": (
+                        f"Do these diffs contain any issues? Can they be improved?\n"
+                        f"{STEP_BY_STEP}"
+                    ),
                 },
             ],
         )

--- a/code_reviewer.py
+++ b/code_reviewer.py
@@ -26,6 +26,7 @@ PROMPT_BASE = (
 # https://openreview.net/forum?id=92gvk82DE-
 STEP_BY_STEP = "Let’s work this out in a step by step way to be sure we have the right answer"
 
+
 class CodeReviewer:
     @staticmethod
     async def review_code_diff(file_name: str, diff: str):


### PR DESCRIPTION
- Improve language for correct English in the prompt
- Factor out the Base Prompt so the common parts are identical for single/multiple diff reviews
- Remove duplicated "Let's work this out in a step by step way to be sure we have the right answer.\n"

Note: I haven't actually run the code since making these changes.